### PR TITLE
show clap help text by default

### DIFF
--- a/src/bin/bumblefoot.rs
+++ b/src/bin/bumblefoot.rs
@@ -1,4 +1,5 @@
 mod cmd;
+use anyhow::anyhow;
 use console::style;
 use std::process::exit;
 
@@ -24,7 +25,7 @@ fn main() {
         );
     }
     let res = match matches.subcommand() {
-        None => cmd::default::run(&matches),
+        None => Err(anyhow!("command not found")),
         Some(tup) => match tup {
             ("validate", subcommand_matches) => cmd::validate::run(&matches, subcommand_matches),
             _ => unreachable!(),

--- a/src/bin/cmd/default.rs
+++ b/src/bin/cmd/default.rs
@@ -1,12 +1,12 @@
-use anyhow::Result as AnyResult;
-use bumblefoot_lib;
 use clap::crate_version;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, AppSettings, Arg};
+
 pub fn command() -> App<'static> {
     App::new("bumblefoot")
         .version(env!("VERGEN_GIT_SEMVER"))
         .version(crate_version!())
         .about("A starter project for Rust")
+        .setting(AppSettings::ArgRequiredElseHelp)
         .arg(
             Arg::new("dry_run")
                 .short('d')
@@ -36,11 +36,4 @@ pub fn command() -> App<'static> {
                 .about("Show details about interactions")
                 .takes_value(false),
         )
-}
-
-pub fn run(matches: &ArgMatches) -> AnyResult<bool> {
-    log::info!("default cmd {:?}", matches.value_of("reporter"));
-    println!("going to run {}", bumblefoot_lib::CMD);
-    bumblefoot_lib::run();
-    Ok(true)
 }

--- a/src/bin/cmd/validate.rs
+++ b/src/bin/cmd/validate.rs
@@ -1,4 +1,5 @@
 use anyhow::Result as AnyResult;
+use bumblefoot_lib;
 use clap::{App, Arg, ArgMatches};
 
 pub fn command() -> App<'static> {
@@ -20,5 +21,7 @@ pub fn command() -> App<'static> {
 }
 
 pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> AnyResult<bool> {
+    println!("going to run {}", bumblefoot_lib::CMD);
+    bumblefoot_lib::run();
     Ok(true)
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,7 +8,7 @@ pub struct Definitions {
     pub providers: HashMap<String, String>,
 }
 
-pub const CMD: &str = r#"hello"#;
+pub const CMD: &str = r#"validate"#;
 
 #[cfg(test)]
 mod tests {
@@ -16,6 +16,6 @@ mod tests {
 
     #[test]
     fn test_foo() {
-        assert_eq!(CMD.len(), 5);
+        assert_eq!(CMD.len(), 8);
     }
 }


### PR DESCRIPTION
add by default clap help text by adding [AppSettings::ArgRequiredElseHelp](https://docs.rs/clap/2.31.1/clap/enum.AppSettings.html#variant.ArgRequiredElseHelp) to the app settings

### expected behavior:
if running the binary without any command, show the --help automatically


to keep the bumblefoot_lib usage example, I move the login to validate the cmd