### PR TITLE
settup clap with ArgRequiredElseHelp

### DIFF
--- a/bumblefoot/src/bin/bumblefoot.rs
+++ b/bumblefoot/src/bin/bumblefoot.rs
@@ -1,4 +1,5 @@
 mod cmd;
+use anyhow::anyhow;
 use console::style;
 use std::process::exit;
 
@@ -24,7 +25,7 @@ fn main() {
         );
     }
     let res = match matches.subcommand() {
-        None => cmd::default::run(&matches),
+        None => Err(anyhow!("command not found")),
         Some(tup) => match tup {
             ("validate", subcommand_matches) => cmd::validate::run(&matches, subcommand_matches),
             _ => unreachable!(),

--- a/bumblefoot/src/bin/cmd/default.rs
+++ b/bumblefoot/src/bin/cmd/default.rs
@@ -1,13 +1,12 @@
-use anyhow::Result as AnyResult;
-use bumblefoot;
 use clap::crate_version;
-use clap::{Arg, ArgMatches, Command};
+use clap::{AppSettings, Arg, Command};
 
 pub fn command() -> Command<'static> {
     Command::new("bumblefoot")
         .version(env!("VERGEN_GIT_SEMVER"))
         .version(crate_version!())
         .about("A starter project for Rust")
+        .setting(AppSettings::ArgRequiredElseHelp)
         .arg(
             Arg::new("dry_run")
                 .short('d')
@@ -37,11 +36,4 @@ pub fn command() -> Command<'static> {
                 .help("Show details about interactions")
                 .takes_value(false),
         )
-}
-
-pub fn run(matches: &ArgMatches) -> AnyResult<bool> {
-    log::info!("default cmd {:?}", matches.value_of("reporter"));
-    println!("going to run {}", bumblefoot::CMD);
-    bumblefoot::run();
-    Ok(true)
 }

--- a/bumblefoot/src/bin/cmd/validate.rs
+++ b/bumblefoot/src/bin/cmd/validate.rs
@@ -20,5 +20,7 @@ pub fn command() -> Command<'static> {
 }
 
 pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> AnyResult<bool> {
+    println!("going to run {}", bumblefoot::CMD);
+    bumblefoot::run();
     Ok(true)
 }

--- a/bumblefoot/src/data.rs
+++ b/bumblefoot/src/data.rs
@@ -8,7 +8,7 @@ pub struct Definitions {
     pub providers: HashMap<String, String>,
 }
 
-pub const CMD: &str = r#"hello"#;
+pub const CMD: &str = r#"validate"#;
 
 #[cfg(test)]
 mod tests {
@@ -16,6 +16,6 @@ mod tests {
 
     #[test]
     fn test_foo() {
-        assert_eq!(CMD.len(), 5);
+        assert_eq!(CMD.len(), 8);
     }
 }


### PR DESCRIPTION
add by default clap help text by adding [AppSettings::ArgRequiredElseHelp](https://docs.rs/clap/2.31.1/clap/enum.AppSettings.html#variant.ArgRequiredElseHelp) to the app settings

If the user runs the binary without a required args, show the --help automatically.

I removed the default run command under the default.rs; if the command is not given, we show the --help text automatically

How to test, 
run the binary without any command
```
cargo run
# or
target/debug/bumblefoot
```