### PR TITLE
setup log level

### DIFF
--- a/bumblefoot/src/bin/bumblefoot.rs
+++ b/bumblefoot/src/bin/bumblefoot.rs
@@ -7,14 +7,16 @@ pub const BANNER: &str = r#"
 "#;
 
 fn main() {
-    // just use $ LOG=1 mybin
-    let env = env_logger::Env::default().filter_or("LOG", "info");
-    env_logger::init_from_env(env);
-
     let app = cmd::default::command().subcommand(cmd::validate::command());
 
     let v = app.render_version();
     let matches = app.to_owned().get_matches();
+
+    let env = env_logger::Env::default().filter_or(
+        "LOG",
+        matches.value_of("log").unwrap_or(log::Level::Info.as_str()),
+    );
+    env_logger::init_from_env(env);
 
     if !matches.is_present("no_banner") {
         println!(

--- a/bumblefoot/src/bin/cmd/default.rs
+++ b/bumblefoot/src/bin/cmd/default.rs
@@ -32,10 +32,21 @@ pub fn command() -> Command<'static> {
                 .takes_value(false),
         )
         .arg(
-            Arg::new("verbose")
-                .long("verbose")
-                .help("Show details about interactions")
-                .takes_value(false),
+            Arg::new("log")
+                .long("log")
+                .help("Set logging level")
+                .value_name("LEVEL")
+                .possible_values(vec![
+                    log::LevelFilter::Off.as_str(),
+                    log::LevelFilter::Trace.as_str(),
+                    log::LevelFilter::Debug.as_str(),
+                    log::LevelFilter::Info.as_str(),
+                    log::LevelFilter::Warn.as_str(),
+                    log::LevelFilter::Error.as_str(),
+                ])
+                .default_value(log::Level::Info.as_str())
+                .ignore_case(true)
+                .takes_value(true),
         )
 }
 


### PR DESCRIPTION
Implement support log level as part of the template. related issue #5 

1. add all the log-level options as a clap `possible_values`
2. set info level as default
3. override from an environment variable if `LOG` is exists

#### flag:
```sh
bumblefoot --log <LEVEL>
```

#### Take from env:
```sh
LOG=<LEVEL> bumblefoot 
```


