### PR TITLE
return exitcode instead of bool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "clap",
  "console",
  "env_logger",
+ "exitcode",
  "log",
  "serde",
  "serde_derive",
@@ -166,6 +167,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"

--- a/bumblefoot/Cargo.toml
+++ b/bumblefoot/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "^0.9.0"
 log = "^0.4.17"
 anyhow = "1"
 console = "^0.15.0"
+exitcode = "1.1.2"
 
 [build-dependencies]
 vergen = "7"

--- a/bumblefoot/Cargo.toml
+++ b/bumblefoot/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "^0.9.0"
 log = "^0.4.17"
 anyhow = "1"
 console = "^0.15.0"
-exitcode = "1.1.2"
+exitcode = "^1.1.2"
 
 [build-dependencies]
 vergen = "7"

--- a/bumblefoot/src/bin/bumblefoot.rs
+++ b/bumblefoot/src/bin/bumblefoot.rs
@@ -2,6 +2,7 @@ mod cmd;
 use console::{style, Style};
 use std::process::exit;
 
+const DEFAULT_ERR_EXIT_CODE: i32 = 1;
 pub const BANNER: &str = r#"
     B A N N E R
 "#;
@@ -31,13 +32,22 @@ fn main() {
         },
     };
 
-    if let Some(message) = res.message {
-        let style = if exitcode::is_success(res.code) {
-            Style::new().green()
-        } else {
-            Style::new().red()
-        };
-        eprintln!("{}", style.apply_to(message));
-    }
-    exit(res.code)
+    let exit_with = match res {
+        Ok(cmd) => {
+            if let Some(message) = cmd.message {
+                let style = if exitcode::is_success(cmd.code) {
+                    Style::new().green()
+                } else {
+                    Style::new().red()
+                };
+                eprintln!("{}", style.apply_to(message));
+            }
+            cmd.code
+        }
+        Err(e) => {
+            log::debug!("{:?}", e);
+            DEFAULT_ERR_EXIT_CODE
+        }
+    };
+    exit(exit_with)
 }

--- a/bumblefoot/src/bin/bumblefoot.rs
+++ b/bumblefoot/src/bin/bumblefoot.rs
@@ -1,5 +1,5 @@
 mod cmd;
-use console::style;
+use console::{style, Style};
 use std::process::exit;
 
 pub const BANNER: &str = r#"
@@ -31,13 +31,13 @@ fn main() {
         },
     };
 
-    match res {
-        Ok(ok) => {
-            exit(if ok { 0 } else { 1 });
-        }
-        Err(err) => {
-            eprintln!("error: {}", err);
-            exit(1)
-        }
+    if let Some(message) = res.message {
+        let style = if exitcode::is_success(res.code) {
+            Style::new().green()
+        } else {
+            Style::new().red()
+        };
+        eprintln!("{}", style.apply_to(message));
     }
+    exit(res.code)
 }

--- a/bumblefoot/src/bin/cmd/default.rs
+++ b/bumblefoot/src/bin/cmd/default.rs
@@ -1,4 +1,3 @@
-use anyhow::Result as AnyResult;
 use bumblefoot;
 use clap::crate_version;
 use clap::{Arg, ArgMatches, Command};

--- a/bumblefoot/src/bin/cmd/default.rs
+++ b/bumblefoot/src/bin/cmd/default.rs
@@ -39,9 +39,12 @@ pub fn command() -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> AnyResult<bool> {
+pub fn run(matches: &ArgMatches) -> bumblefoot::CmdExit {
     log::info!("default cmd {:?}", matches.value_of("reporter"));
     println!("going to run {}", bumblefoot::CMD);
     bumblefoot::run();
-    Ok(true)
+    bumblefoot::CmdExit {
+        code: exitcode::OK,
+        message: None,
+    }
 }

--- a/bumblefoot/src/bin/cmd/default.rs
+++ b/bumblefoot/src/bin/cmd/default.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bumblefoot;
 use clap::crate_version;
 use clap::{Arg, ArgMatches, Command};
@@ -38,12 +39,12 @@ pub fn command() -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> bumblefoot::CmdExit {
+pub fn run(matches: &ArgMatches) -> Result<bumblefoot::CmdExit> {
     log::info!("default cmd {:?}", matches.value_of("reporter"));
     println!("going to run {}", bumblefoot::CMD);
     bumblefoot::run();
-    bumblefoot::CmdExit {
+    Ok(bumblefoot::CmdExit {
         code: exitcode::OK,
         message: None,
-    }
+    })
 }

--- a/bumblefoot/src/bin/cmd/validate.rs
+++ b/bumblefoot/src/bin/cmd/validate.rs
@@ -19,6 +19,9 @@ pub fn command() -> Command<'static> {
         )
 }
 
-pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> AnyResult<bool> {
-    Ok(true)
+pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> bumblefoot::CmdExit {
+    bumblefoot::CmdExit {
+        code: exitcode::OK,
+        message: None,
+    }
 }

--- a/bumblefoot/src/bin/cmd/validate.rs
+++ b/bumblefoot/src/bin/cmd/validate.rs
@@ -1,4 +1,3 @@
-use anyhow::Result as AnyResult;
 use clap::{Arg, ArgMatches, Command};
 
 pub fn command() -> Command<'static> {

--- a/bumblefoot/src/bin/cmd/validate.rs
+++ b/bumblefoot/src/bin/cmd/validate.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::{Arg, ArgMatches, Command};
 
 pub fn command() -> Command<'static> {
@@ -18,9 +19,9 @@ pub fn command() -> Command<'static> {
         )
 }
 
-pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> bumblefoot::CmdExit {
-    bumblefoot::CmdExit {
+pub fn run(_matches: &ArgMatches, _subcommand_matches: &ArgMatches) -> Result<bumblefoot::CmdExit> {
+    Ok(bumblefoot::CmdExit {
         code: exitcode::OK,
         message: None,
-    }
+    })
 }

--- a/bumblefoot/src/data.rs
+++ b/bumblefoot/src/data.rs
@@ -2,7 +2,7 @@
 // use anyhow::Result as AnyResult;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-extern crate exitcode;
+use exitcode;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Definitions {

--- a/bumblefoot/src/data.rs
+++ b/bumblefoot/src/data.rs
@@ -1,8 +1,8 @@
 // use anyhow::anyhow;
 // use anyhow::Result as AnyResult;
+use exitcode;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-use exitcode;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Definitions {

--- a/bumblefoot/src/data.rs
+++ b/bumblefoot/src/data.rs
@@ -2,10 +2,16 @@
 // use anyhow::Result as AnyResult;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
+extern crate exitcode;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Definitions {
     pub providers: HashMap<String, String>,
+}
+
+pub struct CmdExit {
+    pub code: exitcode::ExitCode,
+    pub message: Option<String>,
 }
 
 pub const CMD: &str = r#"hello"#;

--- a/bumblefoot/src/data.rs
+++ b/bumblefoot/src/data.rs
@@ -1,6 +1,5 @@
 // use anyhow::anyhow;
 // use anyhow::Result as AnyResult;
-use exitcode;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/bumblefoot/src/lib.rs
+++ b/bumblefoot/src/lib.rs
@@ -1,4 +1,4 @@
 mod data;
 mod runner;
 pub use self::runner::run;
-pub use data::CMD;
+pub use data::{CmdExit, CMD};


### PR DESCRIPTION
following #6 issue, i have change the cmd return value from bool to [exitcode](https://rust-cli.github.io/book/in-depth/exit-code.html#:~:text=Currently%2C%20Rust%20sets%20an%20exit,101%20when%20the%20process%20panicked.)

Also added the option to pass a custom message with different style depending on the exit code 